### PR TITLE
Fix the issue that lower/uppercase of files are not correctly handeled

### DIFF
--- a/src/main/java/jd/core/CaseInsensitiveFilePathSet.java
+++ b/src/main/java/jd/core/CaseInsensitiveFilePathSet.java
@@ -1,0 +1,31 @@
+package jd.core;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class CaseInsensitiveFilePathSet {
+
+    Set<String> set = new HashSet<String>();
+
+    public void add(String path) {
+        set.add(path.toLowerCase());
+    }
+
+    public boolean containsIgnoreCase(String path) {
+        return set.contains(path.toLowerCase());
+    }
+
+    public String getNumberedName(String path) {
+        int lastComma = path.lastIndexOf('.');
+        String withoutExt = path.substring(0, lastComma);
+        String ext = path.substring(lastComma + 1);
+        for (int i = 2; i < 100; i++) {
+            String newName = withoutExt + "." + i + "." + ext;
+            if (!this.containsIgnoreCase(newName)) {
+                return newName;
+            }
+        }
+        // give up after 100 trials...
+        return path;
+    }
+}

--- a/src/main/java/jd/core/FileSystem.java
+++ b/src/main/java/jd/core/FileSystem.java
@@ -1,0 +1,33 @@
+package jd.core;
+
+import java.io.File;
+import java.io.IOException;
+
+public class FileSystem {
+
+    // -1 = unset, 0 = false, 1 = true;
+    private static int isCaseSensitive = -1;
+
+    public static boolean isCaseSensitive() throws IOException {
+        if (isCaseSensitive != -1) {
+            return isCaseSensitive == 1;
+        }
+        if (testCaseSensitivity()) {
+            isCaseSensitive = 1;
+            return true;
+        } else {
+            isCaseSensitive = 0;
+            return false;
+        }
+    }
+
+    private static boolean testCaseSensitivity() throws IOException {
+        File tempFile = File.createTempFile("jd-core-java", null);
+        String upperCaseName = tempFile.getAbsolutePath().toUpperCase();
+        if (new File(upperCaseName).exists()) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
I have the following issue on the case-insensitive file system like OS X.

Let's say we have two classes `com.example.a` and `com.example.A` in jar file. After decompiling it, I observe only `A.java` is created and the content is actually class `a`. This happens because file system can be case-insensitive, while java class name is case-sensitive in jar file.

To resolve it, I employed the same way as [`smali` did](https://code.google.com/p/smali/issues/detail?id=35). My change is detecting file system's case sensitivity and if it's case-insensitive, use the numbered name as output file name (in former example, class A is decompiled into A.2.java).
