### PR TITLE
i386 arch is properly recognized as an x86 type

### DIFF
--- a/src/main/java/jd/ide/intellij/JavaDecompiler.java
+++ b/src/main/java/jd/ide/intellij/JavaDecompiler.java
@@ -39,7 +39,9 @@ public class JavaDecompiler {
             return "x86";
         } else if("amd64".equals(arch) || "x86_64".equals(arch)) {
             return "x86_64";
-        }
+        } else if("i386".equals(arch)) {
+				return "x86";
+		  }
 
         throw new RuntimeException("Unknown architecture, found " + arch);
     }


### PR DESCRIPTION
if you have an i386 architecture (like a VM in my case) program fails to run correctly due to this check.
