### PR TITLE
use HTTPS and Gradle 4.10.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip


### PR DESCRIPTION
- plain HTTP gives a 403 now
- Gradle 1.11 does not work with current Java:
```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine java version from '14.0.2'.
```