### PR TITLE
Upgrade Gradle version

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.11-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip


### PR DESCRIPTION
Build currently fails on up-to-date systems, since never JDK versions are only supported with newer Gradle versions. This PR updates Gradle version to the latest.

Tested the complete build and everything seems to work as expected after the change.